### PR TITLE
FIX: Context is not longer explicitly cancelled.

### DIFF
--- a/pkg/googlecloud/publisher.go
+++ b/pkg/googlecloud/publisher.go
@@ -76,8 +76,7 @@ func NewPublisher(config PublisherConfig, logger watermill.LoggerAdapter) (*Publ
 		logger: logger,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), config.ConnectTimeout)
-	defer cancel()
+	ctx, _ := context.WithTimeout(context.Background(), config.ConnectTimeout)
 
 	var err error
 	pub.client, err = pubsub.NewClient(ctx, config.ProjectID, config.ClientOptions...)
@@ -100,8 +99,7 @@ func (p *Publisher) Publish(topic string, messages ...*message.Message) error {
 		return ErrPublisherClosed
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), p.config.PublishTimeout)
-	defer cancel()
+	ctx, _ := context.WithTimeout(context.Background(), p.config.PublishTimeout)
 
 	t, err := p.topic(ctx, topic)
 	if err != nil {

--- a/pkg/googlecloud/subscriber.go
+++ b/pkg/googlecloud/subscriber.go
@@ -115,8 +115,7 @@ func NewSubscriber(
 ) (*Subscriber, error) {
 	config.setDefaults()
 
-	ctx, cancel := context.WithTimeout(context.Background(), config.ConnectTimeout)
-	defer cancel()
+	ctx, _ := context.WithTimeout(context.Background(), config.ConnectTimeout)
 
 	client, err := pubsub.NewClient(ctx, config.ProjectID, config.ClientOptions...)
 	if err != nil {
@@ -201,8 +200,7 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 }
 
 func (s *Subscriber) SubscribeInitialize(topic string) (err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), s.config.InitializeTimeout)
-	defer cancel()
+	ctx, _ := context.WithTimeout(context.Background(), s.config.InitializeTimeout)
 
 	subscriptionName := s.config.GenerateSubscriptionName(topic)
 	logFields := watermill.LogFields{


### PR DESCRIPTION
The problem occured when connecting with an actual google cloud pub/sub and not the emulator.
When a newPublisher or a newSubcriber is created a context with timeout is created and the cancel() is placed in a defer. But this also means that at the end of the function the cancel() method is always called. Which cancels the context and thus prohibites the context from being used. 

My fix is that the cancel() method can no longer be called explicitly. The context will now only be cancelled after the timeout has happened. 

Interesting link related to this topic: [context cancellation](https://www.sohamkamani.com/blog/golang/2018-06-17-golang-using-context-cancellation/)