### PR TITLE
Added configuration to auto resume publishing upon error with ordering key

### DIFF
--- a/pkg/googlecloud/publisher.go
+++ b/pkg/googlecloud/publisher.go
@@ -42,6 +42,8 @@ type PublisherConfig struct {
 	DoNotCreateTopicIfMissing bool
 	// Enables the topic message ordering
 	EnableMessageOrdering bool
+	// Enables automatic resume publish upon error
+	EnableMessageOrderingAutoResumePublishOnError bool
 
 	// ConnectTimeout defines the timeout for connecting to Pub/Sub
 	ConnectTimeout time.Duration
@@ -162,6 +164,9 @@ func (p *Publisher) Publish(topic string, messages ...*message.Message) error {
 
 		_, err = result.Get(ctx)
 		if err != nil {
+			if p.config.EnableMessageOrdering && p.config.EnableMessageOrderingAutoResumePublishOnError && googlecloudMsg.OrderingKey != "" {
+				t.ResumePublish(googlecloudMsg.OrderingKey)
+			}
 			return errors.Wrapf(err, "publishing message %s failed", msg.UUID)
 		}
 


### PR DESCRIPTION
At the moment if a any error occurs while publishing and sorting key is set, google cloud pubsub library would refuse to send any subsequent messages to that topic with that sorting key until topic.ResumePublish(sortingKey) is called

Here is an example case:
```
publishing message 5ad8cdc0-c34b-484b-8312-ac42a6a3cdbf failed: context deadline exceeded
publishing message 813e3e65-835d-4151-a183-a7ba26501e20 failed: pubsub: Publishing for ordering key, 123456789, paused due to previous error. Call topic.ResumePublish(orderingKey) before resuming publishing
publishing message dc126f43-027c-466d-83a5-6018b831302f failed: pubsub: Publishing for ordering key, 123456789, paused due to previous error. Call topic.ResumePublish(orderingKey) before resuming publishing
```

Reference from Google Cloud docs https://cloud.google.com/pubsub/docs/samples/pubsub-resume-publish-with-ordering-keys