### PR TITLE
Adding Server-Generated Message ID To Received Message Attributes

### DIFF
--- a/pkg/googlecloud/marshaler.go
+++ b/pkg/googlecloud/marshaler.go
@@ -20,9 +20,9 @@ type Unmarshaler interface {
 // UUIDHeaderKey is the key of the Pub/Sub attribute that carries Waterfall UUID.
 const UUIDHeaderKey = "_watermill_message_uuid"
 
-// GoogleMessageIdHeaderKey is the key of the Pub/Sub attribute that carries Google Cloud Message ID.
+// GoogleMessageIDHeaderKey is the key of the Pub/Sub attribute that carries Google Cloud Message ID.
 // This ID is assigned by the server when the message is published and is guaranteed to be unique within the topic.
-const GoogleMessageIdHeaderKey = "_watermill_message_google_message_id"
+const GoogleMessageIDHeaderKey = "_watermill_message_google_message_id"
 
 // DefaultMarshalerUnmarshaler implements Marshaler and Unmarshaler in the following way:
 // All Google Cloud Pub/Sub attributes are equivalent to Waterfall Message metadata.
@@ -68,7 +68,7 @@ func (DefaultMarshalerUnmarshaler) Unmarshal(pubsubMsg *pubsub.Message) (*messag
 	}
 
 	metadata.Set("publishTime", pubsubMsg.PublishTime.String())
-	metadata.Set(GoogleMessageIdHeaderKey, pubsubMsg.ID)
+	metadata.Set(GoogleMessageIDHeaderKey, pubsubMsg.ID)
 
 	msg := message.NewMessage(id, pubsubMsg.Data)
 	msg.Metadata = metadata

--- a/pkg/googlecloud/marshaler.go
+++ b/pkg/googlecloud/marshaler.go
@@ -20,6 +20,10 @@ type Unmarshaler interface {
 // UUIDHeaderKey is the key of the Pub/Sub attribute that carries Waterfall UUID.
 const UUIDHeaderKey = "_watermill_message_uuid"
 
+// GoogleMessageIdHeaderKey is the key of the Pub/Sub attribute that carries Google Cloud Message ID.
+// This ID is assigned by the server when the message is published and is guaranteed to be unique within the topic.
+const GoogleMessageIdHeaderKey = "_watermill_message_google_message_id"
+
 // DefaultMarshalerUnmarshaler implements Marshaler and Unmarshaler in the following way:
 // All Google Cloud Pub/Sub attributes are equivalent to Waterfall Message metadata.
 // Waterfall Message UUID is equivalent to an attribute with `UUIDHeaderKey` as key.
@@ -64,6 +68,7 @@ func (DefaultMarshalerUnmarshaler) Unmarshal(pubsubMsg *pubsub.Message) (*messag
 	}
 
 	metadata.Set("publishTime", pubsubMsg.PublishTime.String())
+	metadata.Set(GoogleMessageIdHeaderKey, pubsubMsg.ID)
 
 	msg := message.NewMessage(id, pubsubMsg.Data)
 	msg.Metadata = metadata

--- a/pkg/googlecloud/publisher.go
+++ b/pkg/googlecloud/publisher.go
@@ -163,13 +163,15 @@ func (p *Publisher) Publish(topic string, messages ...*message.Message) error {
 		result := t.Publish(ctx, googlecloudMsg)
 		<-result.Ready()
 
-		_, err = result.Get(ctx)
+		serverMessageID, err := result.Get(ctx)
 		if err != nil {
 			if p.config.EnableMessageOrdering && p.config.EnableMessageOrderingAutoResumePublishOnError && googlecloudMsg.OrderingKey != "" {
 				t.ResumePublish(googlecloudMsg.OrderingKey)
 			}
 			return errors.Wrapf(err, "publishing message %s failed", msg.UUID)
 		}
+
+		msg.Metadata.Set(GoogleMessageIDHeaderKey, serverMessageID)
 
 		p.logger.Trace("Message published to Google PubSub", logFields)
 	}

--- a/pkg/googlecloud/pubsub_test.go
+++ b/pkg/googlecloud/pubsub_test.go
@@ -194,8 +194,8 @@ func TestReceivedMessageContainsMessageId(t *testing.T) {
 	produceMessages(t, topic, howManyMessages)
 
 	msg := <-messages
-	if msg.Metadata.Get(googlecloud.GoogleMessageIdHeaderKey) == "" {
-		t.Fatalf("Message %s does not contain %s", msg.UUID, googlecloud.GoogleMessageIdHeaderKey)
+	if msg.Metadata.Get(googlecloud.GoogleMessageIDHeaderKey) == "" {
+		t.Fatalf("Message %s does not contain %s", msg.UUID, googlecloud.GoogleMessageIDHeaderKey)
 	}
 }
 


### PR DESCRIPTION
This merge request resolves the issue I raised in [#430](https://github.com/ThreeDotsLabs/watermill/issues/430) regarding missing server-generated message IDs in Watermill's Google Cloud Pub/Sub implementation. The change made is:

Server-Side Message ID Inclusion:
Modified the googlecloud package's default unmarshaller method to include Google's server-generated message IDs in message attributes, enabling users to access them.
A custom metadata key was created to avoid clash with existing implementations.

Test Coverage:
Added tests to ensure message IDs are present in received messages,

Expected Impact:
Improved compatibility with Google Cloud Pub/Sub.

Additional Notes:

Feedback is welcome for further refinement.