### PR TITLE
feature: skip topic check

### DIFF
--- a/pkg/googlecloud/publisher.go
+++ b/pkg/googlecloud/publisher.go
@@ -37,6 +37,9 @@ type PublisherConfig struct {
 	// ProjectID is the Google Cloud Engine project ID.
 	ProjectID string
 
+	// If true, `Publisher` does not check if the topic exists before publishing.
+	DoNotCheckTopicExistence bool
+
 	// If false (default), `Publisher` tries to create a topic if there is none with the requested name.
 	// Otherwise, trying to subscribe to non-existent subscription results in `ErrTopicDoesNotExist`.
 	DoNotCreateTopicIfMissing bool
@@ -220,6 +223,10 @@ func (p *Publisher) topic(ctx context.Context, topic string) (t *pubsub.Topic, e
 	// different instances of publisher may be used then
 	if p.config.PublishSettings != nil {
 		t.PublishSettings = *p.config.PublishSettings
+	}
+
+	if p.config.DoNotCheckTopicExistence {
+		return t, nil
 	}
 
 	exists, err := t.Exists(ctx)

--- a/pkg/googlecloud/pubsub_test.go
+++ b/pkg/googlecloud/pubsub_test.go
@@ -234,6 +234,24 @@ func TestPublishedMessageIdMatchesReceivedMessageId(t *testing.T) {
 	}
 }
 
+func TestPublisherDoesNotAttemptToCreateTopic(t *testing.T) {
+	topic := fmt.Sprintf("missing_topic_%d", rand.Int())
+
+	// Set up publisher
+	pub, err := googlecloud.NewPublisher(googlecloud.PublisherConfig{
+		// DoNotCheckTopicExistence is set to true, so the publisher will not check
+		// if the topic exists and will also not attempt to create it.
+		DoNotCheckTopicExistence:  true,
+		DoNotCreateTopicIfMissing: false,
+	}, nil)
+	require.NoError(t, err)
+	defer pub.Close()
+
+	// Publish a message
+	publishedMsg := message.NewMessage(watermill.NewUUID(), []byte{})
+	require.Error(t, pub.Publish(topic, publishedMsg), googlecloud.ErrTopicDoesNotExist)
+}
+
 func produceMessages(t *testing.T, topic string, howMany int) {
 	pub, err := googlecloud.NewPublisher(googlecloud.PublisherConfig{}, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
We use watermill-googlecloud to publish messages to Pub/Sub from a few services running in Cloud Run. These services go through spikes and instances are often bounced up and down. 

We noticed that when we have an influx of requests and a lot of messages being published, we sometimes get errors from Pub/Sub when checking if the topic exists. It looks like these APIs are not meant to be used repeatedly (and in many cases concurrently by different instances). 

Bypassing the check got rid of the errors we were seeing in our environment, so I am raising a PR in case this is useful to anyone else.