### PR TITLE
Adds pubsub.ClientConfig to the configuration

### DIFF
--- a/pkg/googlecloud/publisher.go
+++ b/pkg/googlecloud/publisher.go
@@ -56,6 +56,7 @@ type PublisherConfig struct {
 	// Settings for cloud.google.com/go/pubsub client library.
 	PublishSettings *pubsub.PublishSettings
 	ClientOptions   []option.ClientOption
+	ClientConfig    *pubsub.ClientConfig
 
 	Marshaler Marshaler
 }
@@ -113,7 +114,7 @@ func connect(ctx context.Context, config PublisherConfig) (<-chan *pubsub.Client
 		defer close(errc)
 
 		// blocking
-		c, err := pubsub.NewClient(context.Background(), config.ProjectID, config.ClientOptions...)
+		c, err := pubsub.NewClientWithConfig(context.Background(), config.ProjectID, config.ClientConfig, config.ClientOptions...)
 		if err != nil {
 			errc <- err
 			return

--- a/pkg/googlecloud/subscriber.go
+++ b/pkg/googlecloud/subscriber.go
@@ -85,6 +85,7 @@ type SubscriberConfig struct {
 	ReceiveSettings    pubsub.ReceiveSettings
 	SubscriptionConfig pubsub.SubscriptionConfig
 	ClientOptions      []option.ClientOption
+	ClientConfig       *pubsub.ClientConfig
 
 	// Unmarshaler transforms the client library format into watermill/message.Message.
 	// Use a custom unmarshaler if needed, otherwise the default Unmarshaler should cover most use cases.
@@ -419,7 +420,7 @@ func (s *Subscriber) subscription(ctx context.Context, subscriptionName, topicNa
 }
 
 func (s *Subscriber) newClient(ctx context.Context) (*pubsub.Client, error) {
-	client, err := pubsub.NewClient(ctx, s.config.ProjectID, s.config.ClientOptions...)
+	client, err := pubsub.NewClientWithConfig(ctx, s.config.ProjectID, s.config.ClientConfig, s.config.ClientOptions...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The pubsub client has more configuration options that what was being exposed by the watermill configuration structs in the publisher and the subscriber.

This commit adds the missing pubsub.ClientConfig struct to the watermill configuration structs and changes the client initialization to NewClientWithConfig instead of NewClient.

This change is retro-compatible because it defaults to nil, which is the same default value used by the pubsub client.

This this is necessary to enable OpenTelemetry support in pubsub client by setting `EnableOpenTelemetryTracing` in the `ClientConfig` struct.