### PR TITLE
Propagate tracing context to the pubsub sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,11 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
+	go.opentelemetry.io/otel v1.29.0
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sys v0.24.0 // indirect
@@ -42,7 +43,6 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0 // indirect
-	go.opentelemetry.io/otel v1.29.0 // indirect
 	go.opentelemetry.io/otel/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.29.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect

--- a/pkg/googlecloud/publisher.go
+++ b/pkg/googlecloud/publisher.go
@@ -164,7 +164,6 @@ func (p *Publisher) Publish(topic string, messages ...*message.Message) error {
 		}
 
 		result := t.Publish(ctx, googlecloudMsg)
-		<-result.Ready()
 
 		serverMessageID, err := result.Get(ctx)
 		if err != nil {

--- a/pkg/googlecloud/pubsub_test.go
+++ b/pkg/googlecloud/pubsub_test.go
@@ -264,6 +264,25 @@ func TestPublisherDoesNotAttemptToCreateTopic(t *testing.T) {
 	require.Error(t, pub.Publish(topic, publishedMsg), googlecloud.ErrTopicDoesNotExist)
 }
 
+func TestPublisherTimeout(t *testing.T) {
+	topic := fmt.Sprintf("any_topic")
+
+	// Set up publisher
+	pub, err := googlecloud.NewPublisher(googlecloud.PublisherConfig{
+		ProjectID:                 "tests",
+		DoNotCheckTopicExistence:  true,
+		DoNotCreateTopicIfMissing: true,
+		PublishTimeout:            time.Nanosecond,
+	}, nil)
+	require.NoError(t, err)
+	defer pub.Close()
+
+	// Publish a message
+	publishedMsg := message.NewMessage(watermill.NewUUID(), []byte{})
+	err = pub.Publish(topic, publishedMsg)
+	assert.ErrorContains(t, err, "context deadline exceeded")
+}
+
 func produceMessages(t *testing.T, topic string, howMany int) {
 	pub, err := googlecloud.NewPublisher(googlecloud.PublisherConfig{
 		ProjectID: "tests",


### PR DESCRIPTION
<!--
Thanks for contributing to Watermill!

The following template aims to help contributors write a good description for their pull requests.
**The more information you provide, the faster we will be able to review and merge your PR.**

Feel free to skip this template for minor changes like typo fixes.

-->

### Motivation / Background

The google pubsub SDK expects tracing information to be present in provided context when open telemetry tracing is enabled.

Even if the `message.Message` contains valid tracing information in `Metadata` and we properly convert it into pubsub message `Attributes`, that is not taken into account when propagating the span, so that the traceparent Attribute gets overwritten with a new root span.

The result of this is that we get totally disconnected spans, once the trace id is not propgated.


### Details

This change extracts any existing tracing information from `Message.Metadata` and injects it into the context provided for the pubsub SDK only if Open Telemetry tracing is enabled for the pubsub client.

Also, I have taken the opportunity to fix the issue https://github.com/ThreeDotsLabs/watermill/issues/562 in a separate commit.

### Alternative approaches considered (if applicable)

I have considered using `Message.Context` as the context to provide for the SDK `Publish` method. However,
when I implemented this strategy several of the tests broke. Also, the implemented strategy seems a more compatible approach, as it is the one used by `otelsarama`.

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [X] I wrote tests for the changes.
  - This was done partially. I could not find a way to easily test this span propagation without adding extra dependencies to the project. I would need a valid otel tracer provider in order for this to work in a testing environment. However, I tested it in a real project with connected telemetry tools (Grafana, Grafana Tempo).
- [X] All tests are passing.
- [X] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - I did not see a need for updating documentation.

