### PR TITLE
Propagate message context to publisher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,10 @@ go 1.23.0
 require (
 	cloud.google.com/go v0.115.1 // indirect
 	cloud.google.com/go/pubsub v1.42.0
-	github.com/ThreeDotsLabs/watermill v1.3.7
+	github.com/ThreeDotsLabs/watermill v1.4.8-0.20250825132336-9e066d39bea6
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ cloud.google.com/go/longrunning v0.5.12/go.mod h1:S5hMV8CDJ6r50t2ubVJSKQVv5u0rmi
 cloud.google.com/go/pubsub v1.42.0 h1:PVTbzorLryFL5ue8esTS2BfehUs0ahyNOY9qcd+HMOs=
 cloud.google.com/go/pubsub v1.42.0/go.mod h1:KADJ6s4MbTwhXmse/50SebEhE4SmUwHi48z3/dHar1Y=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/ThreeDotsLabs/watermill v1.3.7 h1:NV0PSTmuACVEOV4dMxRnmGXrmbz8U83LENOvpHekN7o=
-github.com/ThreeDotsLabs/watermill v1.3.7/go.mod h1:lBnrLbxOjeMRgcJbv+UiZr8Ylz8RkJ4m6i/VN/Nk+to=
+github.com/ThreeDotsLabs/watermill v1.4.8-0.20250825132336-9e066d39bea6 h1:td3E/Sv6ljyodK/L/4dsQkymKO0R9IqmL+Ko83IHtyo=
+github.com/ThreeDotsLabs/watermill v1.4.8-0.20250825132336-9e066d39bea6/go.mod h1:qykQ1+u+K9ElNTBKyCWyTANnpFAeP7t3F3bZFw+n1rs=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -71,11 +71,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.13.0 h1:yitjD5f7jQHhyDsnhKEBU52NdvvdSeGzlAnDPT0hH1s=
 github.com/googleapis/gax-go/v2 v2.13.0/go.mod h1:Z/fvTZXF8/uw7Xu5GuslPw+bplx6SS338j1Is2S+B7A=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/lithammer/shortuuid/v3 v3.0.7 h1:trX0KTHy4Pbwo/6ia8fscyHoGA+mf1jWbPJVuvyJQQ8=
 github.com/lithammer/shortuuid/v3 v3.0.7/go.mod h1:vMk8ke37EmiewwolSO1NLW8vP4ZaKlRuDIi8tWWmAts=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/pkg/googlecloud/publisher.go
+++ b/pkg/googlecloud/publisher.go
@@ -145,7 +145,14 @@ func (p *Publisher) Publish(topic string, messages ...*message.Message) error {
 
 	deadline := time.Now().Add(p.config.PublishTimeout)
 
-	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	var ctx context.Context
+	if len(messages) > 0 {
+		ctx = messages[0].Context()
+	} else {
+		ctx = context.Background()
+	}
+
+	ctx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
 
 	t, err := p.topic(ctx, topic)

--- a/pkg/googlecloud/publisher.go
+++ b/pkg/googlecloud/publisher.go
@@ -151,33 +151,44 @@ func (p *Publisher) Publish(topic string, messages ...*message.Message) error {
 		return err
 	}
 
-	logFields := make(watermill.LogFields, 2)
-	logFields["topic"] = topic
-
 	for _, msg := range messages {
-		logFields["message_uuid"] = msg.UUID
-		p.logger.Trace("Sending message to Google PubSub", logFields)
-
-		googlecloudMsg, err := p.config.Marshaler.Marshal(topic, msg)
+		err = p.publishMessage(pub, msg, topic)
 		if err != nil {
-			return errors.Wrapf(err, "cannot marshal message %s", msg.UUID)
+			return err
 		}
-
-		result := t.Publish(ctx, googlecloudMsg)
-		<-result.Ready()
-
-		serverMessageID, err := result.Get(ctx)
-		if err != nil {
-			if p.config.EnableMessageOrdering && p.config.EnableMessageOrderingAutoResumePublishOnError && googlecloudMsg.OrderingKey != "" {
-				t.ResumePublish(googlecloudMsg.OrderingKey)
-			}
-			return errors.Wrapf(err, "publishing message %s failed", msg.UUID)
-		}
-
-		msg.Metadata.Set(GoogleMessageIDHeaderKey, serverMessageID)
-
-		p.logger.Trace("Message published to Google PubSub", logFields)
 	}
+
+	return nil
+}
+
+func (p *Publisher) publishMessage(pub *pubsub.Publisher, msg *message.Message, topic string) error {
+	ctx, cancel := context.WithTimeout(msg.Context(), p.config.PublishTimeout)
+	defer cancel()
+
+	logFields := watermill.LogFields{
+		"topic":        topic,
+		"message_uuid": msg.UUID,
+	}
+	p.logger.Trace("Sending message to Google PubSub", logFields)
+
+	googlecloudMsg, err := p.config.Marshaler.Marshal(topic, msg)
+	if err != nil {
+		return errors.Wrapf(err, "cannot marshal message %s", msg.UUID)
+	}
+
+	result := pub.Publish(ctx, googlecloudMsg)
+
+	serverMessageID, err := result.Get(ctx)
+	if err != nil {
+		if p.config.EnableMessageOrdering && p.config.EnableMessageOrderingAutoResumePublishOnError && googlecloudMsg.OrderingKey != "" {
+			pub.ResumePublish(googlecloudMsg.OrderingKey)
+		}
+		return errors.Wrapf(err, "publishing message %s failed", msg.UUID)
+	}
+
+	msg.Metadata.Set(GoogleMessageIDHeaderKey, serverMessageID)
+
+	p.logger.Trace("Message published to Google PubSub", logFields)
 
 	return nil
 }

--- a/pkg/googlecloud/pubsub_test.go
+++ b/pkg/googlecloud/pubsub_test.go
@@ -126,7 +126,6 @@ func TestPublishSubscribeOrdering(t *testing.T) {
 }
 
 func TestSubscriberAllowedWhenAttachedToAnotherTopic(t *testing.T) {
-	rand.Seed(time.Now().Unix())
 	testNumber := rand.Int()
 	logger := watermill.NewStdLogger(true, true)
 

--- a/pkg/googlecloud/pubsub_test.go
+++ b/pkg/googlecloud/pubsub_test.go
@@ -134,6 +134,7 @@ func TestSubscriberAllowedWhenAttachedToAnotherTopic(t *testing.T) {
 	}
 
 	sub1, err := googlecloud.NewSubscriber(googlecloud.SubscriberConfig{
+		ProjectID:                "tests",
 		GenerateSubscriptionName: subNameFn,
 	}, logger)
 	require.NoError(t, err)
@@ -141,6 +142,7 @@ func TestSubscriberAllowedWhenAttachedToAnotherTopic(t *testing.T) {
 	topic1 := fmt.Sprintf("topic1_%d", testNumber)
 
 	sub2, err := googlecloud.NewSubscriber(googlecloud.SubscriberConfig{
+		ProjectID:                               "tests",
 		GenerateSubscriptionName:                subNameFn,
 		DoNotEnforceSubscriptionAttachedToTopic: true,
 	}, logger)


### PR DESCRIPTION
* Use message's context for the pubsub's Publish
* Get rid of the <-Result.Ready() https://github.com/ThreeDotsLabs/watermill/issues/562
